### PR TITLE
Require 'cl during runtime

### DIFF
--- a/commander.el
+++ b/commander.el
@@ -30,7 +30,7 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl))
+(require 'cl)
 (require 's)
 (require 'dash)
 


### PR DESCRIPTION
Commander must require `cl` at runtime, to make `case` available when the expanded body of `commander` is actually run.  If `cl` is required at compile time only, `case` is only available while `commander` is expanded (for which it's not actually required), but not necessarily while the expanded body of `commander` is executed.

On Emacs 24.3 and later this makes commander emit a runtime warning about `cl` being required at runtime.  I do not know how to avoid this.  You may want to use `cl-lib` instead, and add a dependency to `cl-lib` for backwards compatibility.
