### PR TITLE
Use string-to-number instead of string-to-int

### DIFF
--- a/examples/command.el
+++ b/examples/command.el
@@ -9,7 +9,7 @@
   (say "Four"))
 
 (defun sum (&rest args)
-  (message "Sum is: %d" (apply '+ (mapcar 'string-to-int args))))
+  (message "Sum is: %d" (apply '+ (mapcar 'string-to-number args))))
 
 (commander
  (option "--say <*>" "..." say)


### PR DESCRIPTION
Hi! Thanks for great work!

I found the code using `string-to-int`, it is obsolete.
It has been removed in recent Emacs (> 27.1) and
`string-to-number` has been implemented in its place.